### PR TITLE
Don't hide player widget's bars if they are not full.

### DIFF
--- a/swf/Widgets/TrueHUD_PlayerWidget.as
+++ b/swf/Widgets/TrueHUD_PlayerWidget.as
@@ -598,7 +598,7 @@ class Widgets.TrueHUD_PlayerWidget extends MovieClip
 			bIsInMountMode = a_bIsInMountMode;
 		}
 		
-		if (a_bForce || (a_health != health || a_maxHealth != maxHealth || a_healthPct != healthPct))
+		if (a_bForce || (a_health != health || a_maxHealth != maxHealth || a_healthPct != healthPct || a_health != a_maxHealth))
 		{
 			var bInstant = false;
 			if (a_bForce || health == -1) // first update, health not set yet
@@ -626,7 +626,7 @@ class Widgets.TrueHUD_PlayerWidget extends MovieClip
 			healthPct = a_healthPct;
 		}
 
-		if (a_bForce || (a_magicka != magicka || a_maxMagicka != maxMagicka || a_magickaPct != magickaPct))
+		if (a_bForce || (a_magicka != magicka || a_maxMagicka != maxMagicka || a_magickaPct != magickaPct || a_magicka != a_maxMagicka))
 		{
 			var bInstant = false;
 			if (a_bForce || magicka == -1) // first update, magicka not set yet
@@ -654,7 +654,7 @@ class Widgets.TrueHUD_PlayerWidget extends MovieClip
 			magickaPct = a_magickaPct;
 		}
 
-		if (a_bForce || (a_stamina != stamina || a_maxStamina != maxStamina || a_staminaPct != staminaPct))
+		if (a_bForce || (a_stamina != stamina || a_maxStamina != maxStamina || a_staminaPct != staminaPct || a_stamina != a_maxStamina))
 		{
 			var bInstant = false;
 			if (a_bForce || stamina == -1) // first update, stamina not set yet


### PR DESCRIPTION
Currently the player widget's bars disappear after a few seconds if their values stop changing.

In a normal situation this is not an issue, but if for some reason an attribute doesn't regen over time, the associated bar disappears, leaving you potentially unaware of the situation.

I've died quite a few times because after a fight the health bar disappeared and I didn't heal, my brain probably thinking "if I don't see the bar, I'm at full health". Next fight, I die in seconds because turns out I only had 50% HP left.

This change simply makes it so that the bars never disappear if their respective value is not at its max.

IMHO this should be the default but if needed I could try and add an option for it in the MCM. But I'm basically clueless in that regard (this is the first time I edit a mod beyond opening xEdit and changing a record) so it might take me some time.